### PR TITLE
Use versioning of `enftun` and `enf-apt-mirror` images

### DIFF
--- a/enf-apt-mirror/Makefile
+++ b/enf-apt-mirror/Makefile
@@ -7,7 +7,8 @@ IMG := $(ORG)/$(NAME)
 .PHONY: push run
 
 build: Dockerfile
-	docker build -t $(IMG):$(VERSION) .
+	docker build -t $(IMG) .
+	docker tag $(IMG):latest $(IMG):$(VERSION)
 
 push:
 	@echo "docker push $(IMG)"

--- a/enf-apt-mirror/Makefile
+++ b/enf-apt-mirror/Makefile
@@ -11,7 +11,8 @@ build: Dockerfile
 	docker tag $(IMG):latest $(IMG):$(VERSION)
 
 push:
-	@echo "docker push $(IMG)"
+	docker push $(IMG):latest
+	docker push $(IMG):$(VERSION)
 
 run:
 	docker run --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 -d --volume ~/git/enf-services/enf-apt-mirror/enf0:/data/enf0:ro --name $(NAME) $(IMG):$(VERSION)

--- a/enf-apt-mirror/Makefile
+++ b/enf-apt-mirror/Makefile
@@ -1,4 +1,5 @@
 # Makefile
+VERSION := 1.0.0
 ORG := xaptum
 NAME := enf-apt-mirror
 IMG := $(ORG)/$(NAME)
@@ -6,13 +7,13 @@ IMG := $(ORG)/$(NAME)
 .PHONY: push run
 
 build: Dockerfile
-	docker build -t $(IMG) .
+	docker build -t $(IMG):$(VERSION) .
 
 push:
 	@echo "docker push $(IMG)"
 
 run:
-	docker run --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 -d --volume ~/git/enf-services/enf-apt-mirror/enf0:/data/enf0:ro --name $(NAME) $(IMG)
+	docker run --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 -d --volume ~/git/enf-services/enf-apt-mirror/enf0:/data/enf0:ro --name $(NAME) $(IMG):$(VERSION)
 
 stop:
 	docker stop $(NAME)

--- a/enf-demo-server/Makefile
+++ b/enf-demo-server/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.0
+VERSION := 1.0.2
 ORG := xaptum
 NAMES   := $(ORG)/enf-demo-server $(ORG)/enf-demo-server-noenf
 

--- a/enf-demo-server/Makefile
+++ b/enf-demo-server/Makefile
@@ -13,7 +13,8 @@ save: $(NAMES:$(ORG)/%=save-%)
 stop: $(NAMES:$(ORG)/%=stop-%)
 
 $(ORG)/%: %.dockerfile
-	docker build --rm --force-rm -t $@:$(VERSION) -f $< .
+	docker build --rm --force-rm -t $@ -f $< .
+	docker tag $@:latest $@:$(VERSION)
 
 run-%: $(ORG)/%
 	docker run -P --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 -d --volume `pwd`/enf0:/data/enf0:ro --name $(<:$(ORG)/%=%) $<:$(VERSION)
@@ -29,7 +30,8 @@ save-%: $(ORG)/%
 	docker save -o $(<:$(ORG)/%=%)_$(VERSION).tar $<:$(VERSION)
 
 push-%: $(ORG)/%
-	docker push $<
+	docker push $<:latest
+	docker push $<:$(VERSION)
 
 clean:
 	rm -f *_$(VERSION).tar

--- a/enf-demo-server/enf-demo-server.dockerfile
+++ b/enf-demo-server/enf-demo-server.dockerfile
@@ -1,4 +1,4 @@
-FROM xaptum/enftun
+FROM xaptum/enftun:1.0.0
 
 RUN apt-get update     && \
     apt-get install -y    \

--- a/enftun/Dockerfile
+++ b/enftun/Dockerfile
@@ -35,6 +35,8 @@ COPY xaptum.list /etc/apt/sources.list.d/xaptum.list
 RUN apt-get update  && \
     apt-get install -y --no-install-recommends      \
       enftun                                        \
+      ca-certificates                               \
+      telnet netcat-openbsd wget curl               \
       iproute2                                   && \
     rm -rf /var/lib/apt/lists/*
 

--- a/enftun/Makefile
+++ b/enftun/Makefile
@@ -8,8 +8,8 @@ IMG := $(ORG)/$(NAME)
 build: Dockerfile
 	docker build -t $(IMG) .
 
-push:
+push: build
 	docker push $(IMG)
 
-shell:
+shell: build
 	docker run --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --volume `pwd`/enf0:/data/enf0:ro -it $(IMG) bash

--- a/enftun/Makefile
+++ b/enftun/Makefile
@@ -7,10 +7,12 @@ IMG := $(ORG)/$(NAME)
 .PHONY: build push shell
 
 build: Dockerfile
-	docker build -t $(IMG):$(VERSION) .
+	docker build -t $(IMG) .
+	docker tag $(IMG):latest $(IMG):$(VERSION)
 
 push: build
-	docker push $(IMG)
+	docker push $(IMG):latest
+	docker push $(IMG):$(VERSION)
 
 shell: build
 	docker run --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --volume `pwd`/enf0:/data/enf0:ro -it $(IMG):$(VERSION) bash

--- a/enftun/Makefile
+++ b/enftun/Makefile
@@ -1,3 +1,4 @@
+VERSION := 1.0.0
 ORG := xaptum
 NAME := enftun
 IMG := $(ORG)/$(NAME)
@@ -6,10 +7,10 @@ IMG := $(ORG)/$(NAME)
 .PHONY: build push shell
 
 build: Dockerfile
-	docker build -t $(IMG) .
+	docker build -t $(IMG):$(VERSION) .
 
 push: build
 	docker push $(IMG)
 
 shell: build
-	docker run --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --volume `pwd`/enf0:/data/enf0:ro -it $(IMG) bash
+	docker run --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --volume `pwd`/enf0:/data/enf0:ro -it $(IMG):$(VERSION) bash

--- a/enftun/Makefile
+++ b/enftun/Makefile
@@ -1,9 +1,9 @@
-# Makefile
 ORG := xaptum
 NAME := enftun
 IMG := $(ORG)/$(NAME)
 
-.PHONY: push run
+.DEFAULT_GOAL := build
+.PHONY: build push shell
 
 build: Dockerfile
 	docker build -t $(IMG) .


### PR DESCRIPTION
This PR:
- Adds version tags for `enftun` and `enf-apt-mirror` images (both are now at `1.0.0`)
- Adds some tools to `enftun` that are useful for testing
  - netcat (the fork that supports IPv6), telnet, wget, and curl
- Bumps `enf-demo-server`'s version (which we had already been using) to `1.0.2`

The newest, versioned, images have been pushed to Docker Hub for `enftun` and `enf-demo-server`, **but not for `enf-apt-mirror`**

fixes #5 
