### PR TITLE
enftun: add support for enftun-keygen

### DIFF
--- a/enftun/Makefile
+++ b/enftun/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.0
+VERSION := 1.1.0
 ORG := xaptum
 NAME := enftun
 IMG := $(ORG)/$(NAME)
@@ -13,6 +13,9 @@ build: Dockerfile
 push: build
 	docker push $(IMG):latest
 	docker push $(IMG):$(VERSION)
+
+keys: build
+	docker run --volume `pwd`/enf0:/data/enf0 -it --entrypoint /usr/bin/enftun-keygen $(IMG):$(VERSION) -c /etc/enftun/enf0.conf -u $(user) -a $(address)
 
 shell: build
 	docker run --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --volume `pwd`/enf0:/data/enf0:ro -it $(IMG):$(VERSION) bash

--- a/enftun/README.md
+++ b/enftun/README.md
@@ -22,11 +22,15 @@ FROM xaptum:enftun
 
 To run this image in a local container:
 - Create a subdirectory named `enf0`
-    ``` 
+    ```
     mkdir enf0
     ```
-- Copy the private key and certificate files generated using the instructions in [enf-services
-README](https://github.com/xaptum/enf-services) into `enf0/`
+- Provision the credentials using the following command by or by
+following the instructions in [enf-services
+README](https://github.com/xaptum/enf-services)
+    ```
+    make keys user=<USERNAME> address=<ADDRESS>
+    ```
 
 - run:
     ```


### PR DESCRIPTION
This PR 
- upgrades the xaptum/enftun image to enftun version 0.7.2, which includes `enftun-keygen`.
- updates the READMEs to use `enftun-keygen` to provision the keys, instead of the `enfcli`.

I'm opening this as a mergeable PR, but am open to suggestions to further improve the flow.

For example:
- prompting for the username and address (like `enftun-keygen` prompts for the password), instead of requiring them as command line arguments.
- ???