### PR TITLE
enf-demo-server: Bind to enf0.

### DIFF
--- a/enf-demo-server/Makefile
+++ b/enf-demo-server/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.3
+VERSION := 1.0.4
 ORG := xaptum
 NAMES   := $(ORG)/enf-demo-server $(ORG)/enf-demo-server-noenf
 

--- a/enf-demo-server/enf-demo-server-noenf.dockerfile
+++ b/enf-demo-server/enf-demo-server-noenf.dockerfile
@@ -11,4 +11,4 @@ COPY xaptum_demo.8080.txt /usr/local/share/xaptum/
 EXPOSE 2332
 EXPOSE 8080
 
-CMD ["/usr/local/bin/xdemo_target_servers", "/usr/local/share/xaptum/", "/var/log/xaptum/xdemo_target_servers.log"]
+CMD ["/usr/local/bin/xdemo_target_servers", "/usr/local/share/xaptum/", "/var/log/xaptum/xdemo_target_servers.log", "::"]

--- a/enf-demo-server/enf-demo-server.dockerfile
+++ b/enf-demo-server/enf-demo-server.dockerfile
@@ -8,4 +8,7 @@ COPY xdemo_target_servers /usr/local/bin
 COPY sierra_wireless.2332.txt /usr/local/share/xaptum/
 COPY xaptum_demo.8080.txt /usr/local/share/xaptum/
 
-CMD ["/usr/local/bin/xdemo_target_servers", "/usr/local/share/xaptum/", "/var/log/xaptum/xdemo_target_servers.log"]
+COPY start_targets.sh /usr/local/bin/
+RUN ln -s usr/local/bin/start_targets.sh / # backwards compat
+
+CMD ["/usr/local/bin/start_targets.sh"]

--- a/enf-demo-server/start_targets.sh
+++ b/enf-demo-server/start_targets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Give ENFTUN a little time to connect
+sleep 5
+
+# Find address of `enf0` interface (which we'll bind to)
+INTERFACE=$(awk '/2607.*enf0/{ print $1 }' /proc/net/if_inet6 | sed -r 's/.{4}/\0:/g;s/:$//g')
+
+/usr/local/bin/xdemo_target_servers /usr/local/share/xaptum/ /var/log/xaptum/xdemo_target_servers.log $INTERFACE


### PR DESCRIPTION
This PR fixes an issue in the `enf-demo-server` sub-project. Previous work in that project updated the `xdemo_target_servers` Python script to take as CLI parameter the address to bind to (this was so the TCP servers would listen only on the `enf0` interface, and thus *actually* be isolated from the local Docker network). However, when this change was made to the Python script, I didn't update the Dockerfile in turn (I made a mental TODO, and of course forgot).

This PR fixes this by:
- Passing `::` to the script for the `enf-demo-server-noenf`
  - Since that container has no `enf0`, it's fine to just blindly listen on all interfaces
- Using some AWK and sed magic to get the address of the `enf0` interface for the `enf-demo-server` container
  - Because this is more complex than the previous `CMD`, and requires a short `sleep` (to ensure `enf0` is up when we're trying to find its address), I moved this new logic into a separate Bash script
