### PR TITLE
Allow conf file to be overridden in`enftun` container, and upgrade to debian/buster

### DIFF
--- a/enftun/Dockerfile
+++ b/enftun/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 MAINTAINER Xaptum
 

--- a/enftun/Dockerfile
+++ b/enftun/Dockerfile
@@ -40,8 +40,8 @@ RUN apt-get update  && \
       iproute2                                   && \
     rm -rf /var/lib/apt/lists/*
 
-# Install enftun configuration
-COPY enf0.conf /etc/enftun/enf0.conf
+# Install default enftun configuration
+COPY enf0.conf /etc/enftun/enf0.conf.default
 
 # Configure entrypoint script
 COPY entrypoint.sh /usr/local/bin/

--- a/enftun/Makefile
+++ b/enftun/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.1.0
+VERSION := 1.3.0
 ORG := xaptum
 NAME := enftun
 IMG := $(ORG)/$(NAME)

--- a/enftun/entrypoint.sh
+++ b/enftun/entrypoint.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 set -e
 
-echo "Setting up enftun"
-/usr/bin/enftun-setup up /etc/enftun/enf0.conf
-/usr/bin/enftun -c /etc/enftun/enf0.conf &
+if [[ -f "/data/enf0/enf0.conf" ]]; then
+    CONF_FILE="/data/enf0/enf0.conf"
+else
+    CONF_FILE="/etc/enftun/enf0.conf.default"
+fi
+
+echo "Setting up enftun using config file '${CONF_FILE}'"
+/usr/bin/enftun-setup up $CONF_FILE 
+/usr/bin/enftun -c $CONF_FILE &
 
 exec "$@"

--- a/enftun/xaptum.list
+++ b/enftun/xaptum.list
@@ -1,1 +1,1 @@
-deb http://dl.bintray.com/xaptum/deb stretch main
+deb http://dl.bintray.com/xaptum/deb buster main


### PR DESCRIPTION
This PR makes the following changes:
- Allow the user the override the `enf0.conf` file when running the container
  - This may be done by providing a `enf0.conf` file in their `enf0/` directory, next to the key and cert
- Upgrades the `enftun` container's base image from debian/stretch to debian/buster.

This new image has been built and pushed to our Docker Hub (with a new version number, which jumps minor version, since I mucked up an earlier version).

NOTE: I did NOT upgrade or rebuild/push any of the other containers.

The immediate impetus for these changes was to use the new enftun package (with IPv4 support), which isn't available on debian/stretch and requires the conf setting `allow_ipv4`.

Also, I've frequently wished I could alter the config file for testing (e.g. point the container at a specific CH2 machine).